### PR TITLE
chore!: Update stdlib dependency to "> 10.0.0" and concat dep to "> 10.0.0"

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -788,4 +788,3 @@ Failure will cause the catalog to fail compilation.
 Optional value. (default: false).
 
 Default value: `$certificates::validate_x509`
-

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -788,3 +788,4 @@ Failure will cause the catalog to fail compilation.
 Optional value. (default: false).
 
 Default value: `$certificates::validate_x509`
+

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.1.1 < 8.0.0"
+      "version_requirement": ">= 1.1.1 < 10.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.12.0 < 9.0.0"
+      "version_requirement": ">= 4.12.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/concat",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,9 +9,9 @@ describe 'certificates', type: :class do
             'osfamily'                  => 'Debian',
             'operatingsystem'           => 'Debian',
             'lsbdistid'                 => 'Debian',
-            'lsbdistcodename'           => 'wheezy',
-            'operatingsystemrelease'    => '7.3',
-            'operatingsystemmajrelease' => '7',
+            'lsbdistcodename'           => 'bookworm',
+            'operatingsystemrelease'    => '12.12',
+            'operatingsystemmajrelease' => '12',
           }
         end
 
@@ -54,8 +54,8 @@ describe 'certificates', type: :class do
           {
             'osfamily'                  => osfamily,
             'operatingsystem'           => 'RedHat',
-            'operatingsystemrelease'    => '7.2',
-            'operatingsystemmajrelease' => '7',
+            'operatingsystemrelease'    => '8.10',
+            'operatingsystemmajrelease' => '8',
           }
         end
 

--- a/spec/defines/site_spec.rb
+++ b/spec/defines/site_spec.rb
@@ -13,11 +13,11 @@ describe 'certificates::site', type: :define do
       if osfamily == 'Debian'
         let(:facts) do
           {
-            'lsbdistcodename'           => 'wheezy',
+            'lsbdistcodename'           => 'bookworm',
             'lsbdistid'                 => 'Debian',
             'operatingsystem'           => 'Debian',
-            'operatingsystemmajrelease' => '9',
-            'operatingsystemrelease'    => '9.5',
+            'operatingsystemmajrelease' => '12',
+            'operatingsystemrelease'    => '12.12',
             'osfamily'                  => 'Debian',
           }
         end
@@ -93,8 +93,8 @@ describe 'certificates::site', type: :define do
         let(:facts) do
           {
             'operatingsystem'           => 'RedHat',
-            'operatingsystemmajrelease' => '7',
-            'operatingsystemrelease'    => '7.5',
+            'operatingsystemmajrelease' => '8',
+            'operatingsystemrelease'    => '8.10',
             'osfamily'                  => osfamily,
           }
         end
@@ -120,11 +120,11 @@ describe 'certificates::site', type: :define do
   context 'on Debian-like setup for the remaining tests' do
     let(:facts) do
       {
-        'lsbdistcodename'           => 'wheezy',
+        'lsbdistcodename'           => 'bookworm',
         'lsbdistid'                 => 'Debian',
         'operatingsystem'           => 'Debian',
-        'operatingsystemmajrelease' => '9',
-        'operatingsystemrelease'    => '9.5',
+        'operatingsystemmajrelease' => '12',
+        'operatingsystemrelease'    => '12.12',
         'osfamily'                  => 'Debian',
       }
     end


### PR DESCRIPTION
Greetings,

we are planing to upgrade to openvox and in preperation we need to upgrade all our puppetmodules.
Stdlib >=9.0.0 is mandatory with a lot of modules by now in Puppet > 8.x
We use this module too and i dont think that the "new" stdlib will have any effekt on the current functions
Also the tests are running like a charm :)

Kind Regards
Max